### PR TITLE
Added 'soundfile' to requirements.txt based on Issue#41

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scipy
 PyAudio
 PySimpleGUI
 sounddevice
+soundfile


### PR DESCRIPTION
I encountered the problem when I ran the command `python3 Amplitude-Frequency-Visualizer.py` after cloning the repository on my local device. It was a dependency issue where the module 'soundfile' had not been installed. I checked the issue section and sure enough there was already an issue #41 

Thus, I have updated the requirements.txt accordingly.