### PR TITLE
Handled window closed and exit cases separately in event loop

### DIFF
--- a/Amplitude-Frequency-Visualizer.py
+++ b/Amplitude-Frequency-Visualizer.py
@@ -108,8 +108,14 @@ fig_agg = draw_figure(graph.TKCanvas, fig)  # draw the figure on the graph
 # MAIN LOOP
 while True:
     event, values = _VARS["window"].read(timeout=TIMEOUT)
-    if event == sg.WIN_CLOSED or event == "Exit":
+    if event == "Exit":
         stop()
+        pAud.terminate()
+        break
+    # for handling the closing of application
+    if event == sg.WIN_CLOSED :
+        _VARS["stream"].stop_stream()
+        _VARS["stream"].close()
         pAud.terminate()
         break
     if event == "Listen":

--- a/Intensity-vs-Frequency-and-time.py
+++ b/Intensity-vs-Frequency-and-time.py
@@ -138,8 +138,14 @@ def compute_intensity_data(audio_data, window_size=1024, hop_size=512):
 # MAIN LOOP
 while True:
     event, values = _VARS["window"].read(timeout=TIMEOUT)
-    if event == sg.WIN_CLOSED or event == "Exit":
+    if event == "Exit":
         stop()
+        pAud.terminate()
+        break
+      # for handling the closing of application
+    if event == sg.WIN_CLOSED :
+        _VARS["stream"].stop_stream()
+        _VARS["stream"].close()
         pAud.terminate()
         break
     if event == "Listen":

--- a/Spectogram.py
+++ b/Spectogram.py
@@ -96,8 +96,14 @@ fig_agg = draw_figure(graph.TKCanvas, fig)  # draw the figure on the graph
 # MAIN LOOP
 while True:
     event, values = _VARS["window"].read(timeout=TIMEOUT)
-    if event == sg.WIN_CLOSED or event == "Exit":
+    if event == "Exit":
         stop()
+        pAud.terminate()
+        break
+    # for handling the closing of application
+    if event == sg.WIN_CLOSED :
+        _VARS["stream"].stop_stream()
+        _VARS["stream"].close()
         pAud.terminate()
         break
     if event == "Listen":

--- a/Waveform.py
+++ b/Waveform.py
@@ -86,8 +86,14 @@ drawAxis()
 # MAIN LOOP
 while True:
     event, values = _VARS["window"].read(timeout=TIMEOUT)
-    if event == sg.WIN_CLOSED or event == "Exit":
+    if event == "Exit":
         stop()
+        pAud.terminate()
+        break
+    # for handling the closing of application
+    if event == sg.WIN_CLOSED :
+        _VARS["stream"].stop_stream()
+        _VARS["stream"].close()
         pAud.terminate()
         break
     if event == "Listen":


### PR DESCRIPTION
#PR Title
Handled window closed and exit cases separately in event loop

## Description
In this PR, I've made changes to handle the window closed and exit cases separately in the event loop of the below specified files.

## Linked Issue
Resolves issue No #37 "Error in ProgressBar Update"  

## Changes and Additions
- Implemented separate handling for window closed and exit cases in the event loops of the following files:
  - `Waveform.py` at line 93
  - `Spectogram.py` at line 103
  - `Amplitude-frequency-visualizer.py` at line 146


## Testing and Validation
I tested the changes by running the affected code and verified that the application behaves correctly when the window is closed or when the exit button is clicked. Additionally, I ensured that the application still functions as expected in other scenarios.

## Additional Context or Information
This change enhances the reliability and user experience of the application by ensuring that closing the window and exiting the application are handled appropriately.

## Checklist
Please ensure you've completed the following tasks:
- [x] Code is up to date with the project's latest version
- [x] All tests have been run and passed
- [x] Code has been reviewed for correctness and readability
- [x] Followed the project's coding guidelines

## References
- [Contribution.md](https://github.com/Soumya-Kushwaha/SoundScape/blob/main/Contribution.md)
- [Installation.md](https://github.com/Soumya-Kushwaha/SoundScape/blob/main/Installation.md)
- [References.md](https://github.com/Soumya-Kushwaha/SoundScape/blob/main/References.md)
